### PR TITLE
Downloading cancelled due to network disconnection

### DIFF
--- a/prdownloader/src/main/java/com/downloader/internal/DownloadRunnable.java
+++ b/prdownloader/src/main/java/com/downloader/internal/DownloadRunnable.java
@@ -48,7 +48,12 @@ public class DownloadRunnable implements Runnable {
         } else if (response.isPaused()) {
             request.deliverPauseEvent();
         } else if (response.getError() != null) {
-            request.deliverError(response.getError());
+            if (response.getError().isConnectionError()) {
+                request.setStatus(Status.PAUSED);
+                request.deliverPauseEvent();
+            } else {
+                request.deliverError(response.getError());
+            }
         } else if (!response.isCancelled()) {
             request.deliverError(new Error());
         }


### PR DESCRIPTION
In case the error is caused by the network, downloading is canceled and progress lost.
Fix: set the state to paused and not canceled in case of a network error. So after the connection is back user can resume from the same point.