### PR TITLE
Bug fixes

### DIFF
--- a/prdownloader/src/main/java/com/downloader/Error.java
+++ b/prdownloader/src/main/java/com/downloader/Error.java
@@ -30,7 +30,7 @@ public class Error {
     private String serverErrorMessage;
     private Map<String, List<String>> headerFields;
     private Throwable connectionException;
-
+    private int responseCode;
 
     public boolean isServerError() {
         return isServerError;
@@ -70,5 +70,13 @@ public class Error {
 
     public Throwable getConnectionException() {
         return connectionException;
+    }
+
+    public void setResponseCode(int responseCode) {
+        this.responseCode = responseCode;
+    }
+
+    public int getResponseCode() {
+        return responseCode;
     }
 }

--- a/prdownloader/src/main/java/com/downloader/Status.java
+++ b/prdownloader/src/main/java/com/downloader/Status.java
@@ -32,6 +32,8 @@ public enum Status {
 
     CANCELLED,
 
+    FAILED,
+
     UNKNOWN
 
 }

--- a/prdownloader/src/main/java/com/downloader/httpclient/DefaultHttpClient.java
+++ b/prdownloader/src/main/java/com/downloader/httpclient/DefaultHttpClient.java
@@ -100,6 +100,14 @@ public class DefaultHttpClient implements HttpClient {
         return connection.getHeaderFields();
     }
 
+    @Override
+    public InputStream getErrorStream() {
+        if (connection instanceof HttpURLConnection) {
+            return ((HttpURLConnection) connection).getErrorStream();
+        }
+        return null;
+    }
+
     private void addHeaders(DownloadRequest request) {
         final HashMap<String, List<String>> headers = request.getHeaders();
         if (headers != null) {

--- a/prdownloader/src/main/java/com/downloader/httpclient/HttpClient.java
+++ b/prdownloader/src/main/java/com/downloader/httpclient/HttpClient.java
@@ -45,4 +45,6 @@ public interface HttpClient extends Cloneable {
 
     Map<String, List<String>> getHeaderFields();
 
+    InputStream getErrorStream() throws IOException;
+
 }

--- a/prdownloader/src/main/java/com/downloader/internal/DownloadTask.java
+++ b/prdownloader/src/main/java/com/downloader/internal/DownloadTask.java
@@ -378,24 +378,26 @@ public class DownloadTask {
         }
     }
 
-    private String convertStreamToString(InputStream errorStream) {
+    private String convertStreamToString(InputStream stream) {
         StringBuilder stringBuilder = new StringBuilder();
-        String line;
-        BufferedReader bufferedReader = null;
-        try {
-            bufferedReader = new BufferedReader(new InputStreamReader(errorStream));
-            while ((line = bufferedReader.readLine()) != null) {
-                stringBuilder.append(line);
-            }
-        } catch (IOException ignored) {
-
-        } finally {
+        if (stream != null) {
+            String line;
+            BufferedReader bufferedReader = null;
             try {
-                if (bufferedReader != null) {
-                    bufferedReader.close();
+                bufferedReader = new BufferedReader(new InputStreamReader(stream));
+                while ((line = bufferedReader.readLine()) != null) {
+                    stringBuilder.append(line);
                 }
-            } catch (NullPointerException | IOException ignored) {
+            } catch (IOException ignored) {
 
+            } finally {
+                try {
+                    if (bufferedReader != null) {
+                        bufferedReader.close();
+                    }
+                } catch (NullPointerException | IOException ignored) {
+
+                }
             }
         }
         return stringBuilder.toString();

--- a/prdownloader/src/main/java/com/downloader/internal/DownloadTask.java
+++ b/prdownloader/src/main/java/com/downloader/internal/DownloadTask.java
@@ -127,7 +127,7 @@ public class DownloadTask {
             if (!isSuccessful()) {
                 Error error = new Error();
                 error.setServerError(true);
-                error.setServerErrorMessage(convertStreamToString());
+                error.setServerErrorMessage(convertStreamToString(httpClient.getErrorStream()));
                 error.setHeaderFields(httpClient.getHeaderFields());
                 response.setError(error);
                 return response;
@@ -378,12 +378,12 @@ public class DownloadTask {
         }
     }
 
-    private String convertStreamToString() {
+    private String convertStreamToString(InputStream errorStream) {
         StringBuilder stringBuilder = new StringBuilder();
         String line;
         BufferedReader bufferedReader = null;
         try {
-            bufferedReader = new BufferedReader(new InputStreamReader(inputStream));
+            bufferedReader = new BufferedReader(new InputStreamReader(errorStream));
             while ((line = bufferedReader.readLine()) != null) {
                 stringBuilder.append(line);
             }

--- a/prdownloader/src/main/java/com/downloader/internal/DownloadTask.java
+++ b/prdownloader/src/main/java/com/downloader/internal/DownloadTask.java
@@ -129,6 +129,7 @@ public class DownloadTask {
                 error.setServerError(true);
                 error.setServerErrorMessage(convertStreamToString(httpClient.getErrorStream()));
                 error.setHeaderFields(httpClient.getHeaderFields());
+                error.setResponseCode(responseCode);
                 response.setError(error);
                 return response;
             }

--- a/prdownloader/src/main/java/com/downloader/request/DownloadRequest.java
+++ b/prdownloader/src/main/java/com/downloader/request/DownloadRequest.java
@@ -237,6 +237,7 @@ public class DownloadRequest {
 
     public void deliverError(final Error error) {
         if (status != Status.CANCELLED) {
+            setStatus(Status.FAILED);
             Core.getInstance().getExecutorSupplier().forMainThreadTasks()
                     .execute(new Runnable() {
                         public void run() {


### PR DESCRIPTION
1. Use error stream instead of input stream to read error message from server
Reason : Documentation of HTTPURLConnection states that when there is a server error, input stream will be null and error stream should be used to read the message

2. Missed to add response code to previous PR

3. Set request status to FAILED if download fails